### PR TITLE
Bugfix in Match and linking issue on gcc 5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_AUTOMOC ON)
 # Locally installed libraries
 find_package(Qt5Core)
 find_package(Qt5Network)
-find_package(Boost REQUIRED COMPONENTS graph system thread coroutine context)
+find_package(Boost REQUIRED COMPONENTS graph system coroutine context thread)
 find_package(PkgConfig)
 pkg_check_modules(GLOG REQUIRED libglog)
 

--- a/src/Match.cc
+++ b/src/Match.cc
@@ -121,5 +121,6 @@ EthAddress operator&(const EthAddress &a, const EthAddress &b)
 
 IPAddress operator&(const IPAddress &a, const IPAddress &b)
 {
-    return fluid_msg::IPAddress();
+    // Only IPV4 version. IPv6 is broken
+    return fluid_msg::IPAddress(const_cast<IPAddress &>(a).getIPv4() & const_cast<IPAddress &>(b).getIPv4());
 }

--- a/src/Match.hh
+++ b/src/Match.hh
@@ -38,7 +38,7 @@ struct oxm_match_impl {
     static bool match(const oxm_type& op, const decltype(oxm_type().value())& value)
     {
         if (op.has_mask())
-            return value == (op.oxm_type::value() & op.oxm_type::mask());
+              return op.oxm_type::value() == (value & op.oxm_type::mask());
         else
             return value == op.oxm_type::value();
     }


### PR DESCRIPTION
Current implementation of IP Matching in Match.hh handles incorrectly ip subnets. This patch fixes ip matching and AND operation for ip address. Only IPv4 is supported.