### PR TITLE
Do not reset library paths

### DIFF
--- a/debug_run_env.sh
+++ b/debug_run_env.sh
@@ -1,5 +1,5 @@
 # Print glog messages
-export DYLD_LIBRARY_PATH=$PWD/prefix/lib # OS X
-export LD_LIBRARY_PATH=$PWD/prefix/lib   # Linux
+export DYLD_LIBRARY_PATH=$PWD/prefix/lib:$DYLD_LIBRARY_PATH # OS X
+export LD_LIBRARY_PATH=$PWD/prefix/lib:$LD_LIBRARY_PATH   # Linux
 export GLOG_logtostderr=1
 export GLOG_colorlogtostderr=1


### PR DESCRIPTION
Being reset, it makes runos running impossible, since it can not find a libraries.